### PR TITLE
+ Parameter for filtering what items will be rated in a CvC task

### DIFF
--- a/jsdoc/typedefs.jsdoc
+++ b/jsdoc/typedefs.jsdoc
@@ -29,7 +29,7 @@
  * pairs to this object. In that case, the system will try to find content
  * that has exactly matching metadata. Such queries might be slower and/or
  * return no results, so use this feature with caution. <br>
- * <i>Do not specify <b>sources</b> and <b>sourceGroups</b> at the same time
+ * <i>Do not specify <b>source</b> and <b>sourceGroup</b> at the same time
  * - one of them will be overwritten!</i>
  * @typedef {Object} ContentFilter
  * @property {String[]} [source] - only match content from these sources

--- a/lib/api-groups/training-api.js
+++ b/lib/api-groups/training-api.js
@@ -102,16 +102,24 @@ function initiateInsightTraining (insightId,
 }
 
 /**
- * Initiate a task for generating recommendations for the specified content
+ * Initiate a task for generating recommendations for the specified content. Recommendations
+ * will be generated from a subset of all Intellogo content, defined by the specified
+ * <code>recommendationsFilters</code>. If the filters are an empty array [], recommendations
+ * will be generated from all content in the system.
+ * <br>
+ * Note: The task will complete faster when the filters are more restrictive.
  * @param {ContentAPI~ContentIdentifier} content The content for which to
  * generate recommendations
+ * @param {ContentFilter[]} [recommendationsFilters] Filters that limit what part
+ * of all Intellogo content will be rated against the specified <code>content</code>.
+ * @param {String} [webhook] A webhook that should be notified of the task completion.
  * @param {IntellogoCallback.<TrainingAPI~ContentRecommendationTask>} [callback]
  * @returns {IntellogoResponse.<TrainingAPI~ContentRecommendationTask>}
  * @method
  */
 TrainingAPI.prototype.initiateContentRecommendationGeneration =
     callbackify(initiateContentRecommendationGeneration);
-function initiateContentRecommendationGeneration (content, webhook) {
+function initiateContentRecommendationGeneration (content, recommendationsFilters, webhook) {
     var data = { }, query = { };
     if (content.contentId) {
         data.contentId = content.contentId;
@@ -121,6 +129,13 @@ function initiateContentRecommendationGeneration (content, webhook) {
             sourceId: content.sourceId
         };
     }
+    if (!webhook && _.isString(recommendationsFilters)) {
+        webhook = recommendationsFilters;
+        recommendationsFilters = null;
+    }
+
+    data.itemsToRate = recommendationsFilters || [];
+
     if (webhook) {
         query.webhookId = webhook;
     }


### PR DESCRIPTION
Allow usage of the REST API parameter for filtering `itemsToRate` in CvC tasks.
