### PR TITLE
Do not set content encoding on empty POST body

### DIFF
--- a/lib/web-bridge.js
+++ b/lib/web-bridge.js
@@ -192,8 +192,7 @@ function WebBridge(apiVersion, options) {
                 'Accept-Encoding': 'identity;q=0.1,deflate;q=0.5,gzip;q=0.7',
                 'Accept': 'application/json, json',
                 'content-type': 'application/json',
-                'User-Agent': 'Intellogo-' + apiVersion + '-oauth',
-                'Content-Encoding': 'gzip'
+                'User-Agent': 'Intellogo-' + apiVersion + '-oauth'
             };
         for (prop in headers) {
             if (headers.hasOwnProperty(prop)) {
@@ -304,6 +303,7 @@ function WebBridge(apiVersion, options) {
 
                 buffer = new Buffer(stringData, 'utf-8');
                 ZLib.gzip(buffer, function (error, data) {
+                    requestObj.setHeader('Content-Encoding', 'gzip');
                     requestObj.setHeader('Content-Length', data.length);
                     requestObj.end(data);
                 });


### PR DESCRIPTION
Fix an issue related to the upgrade to Node.js 6:
When the body is empty and Content-Encoding is set, an error occurs.